### PR TITLE
Added support for running one specific target of a task

### DIFF
--- a/expose.js
+++ b/expose.js
@@ -7,13 +7,28 @@ module.exports = function(grunt) {
     'expose', "Expose available tasks as JSON object.", function () {
       var tasks = grunt.task._tasks;
       _.each( tasks, function( value, key, list ) {
-        var targets = Object.keys(grunt.config.getRaw( key ) || {});
-        if ( targets.length > 0 ) {
+        // We don't want to shouw or own task
+        if (key === 'expose') {
+          delete list[key];
+        }
+        else {
+          // Filter away reservered words that are none-targets
+          var targets = _.difference(Object.keys(grunt.config.getRaw( key ) || {}), ['files', 'options', 'globals']);
+          
+          if ( targets.length > 0 ) {
             list[ key ].targets = targets;
+          
+            if ( targets.length > 1 ) {
+              _.each( targets, function(target) {
+                var name = key + ":" + target;
+
+                list[name] = { name: name, info: 'Targets ' + name + '. ' + list[key].info || '', meta: { info: list[key].meta&&list[key].meta.info} };
+              });
+            }
+          }
         }
       });
       grunt.log.write("EXPOSE_BEGIN" + JSON.stringify(tasks) + "EXPOSE_END");
     }
   );
-
 };


### PR DESCRIPTION
The easiest way to add support for running a specific target of a task. Users will only see targets if there is more then one. No sublime gui change added, only added a "sub" target neath the parent task when there is more then one target in the task. A different solution to the same problem as tvooo/sublime-grunt#24
