### PR TITLE
Added cachehandling to expose task to overcome platform issues

### DIFF
--- a/expose.js
+++ b/expose.js
@@ -1,34 +1,62 @@
+var path = require('path');
+var crypto = require('crypto'),
+    shasum = crypto.createHash('sha1');
+
 module.exports = function(grunt) {
   'use strict';
 
   var _ = grunt.util._;
 
+  function generatesha1(filename) {
+      var content = grunt.file.read(filename);
+ 
+      shasum.update("blob " + content.length + '\0');
+      shasum.update(content);
+
+      return shasum.digest('hex');
+  }
+
   grunt.registerTask(
     'expose', "Expose available tasks as JSON object.", function () {
-      var tasks = grunt.task._tasks;
-      _.each( tasks, function( value, key, list ) {
-        // We don't want to shouw or own task
-        if (key === 'expose') {
-          delete list[key];
-        }
-        else {
-          // Filter away reservered words that are none-targets
-          var targets = _.difference(Object.keys(grunt.config.getRaw( key ) || {}), ['files', 'options', 'globals']);
-          
-          if ( targets.length > 0 ) {
-            list[ key ].targets = targets;
-          
-            if ( targets.length > 1 ) {
-              _.each( targets, function(target) {
-                var name = key + ":" + target;
+      var cwd = process.cwd();
+      var gruntFileName = path.join(cwd, 'Gruntfile.js');
+      var cacheFileName = path.join(cwd, '.sublime-grunt.cache');
+      var sha1 = generatesha1(gruntFileName);
+        
+      var gruntsublimecache = (grunt.file.exists(cacheFileName) && grunt.file.readJSON(cacheFileName)) || {};
 
-                list[name] = { name: name, info: 'Targets ' + name + '. ' + list[key].info || '', meta: { info: list[key].meta&&list[key].meta.info} };
-              });
+      if (!gruntsublimecache[gruntFileName] || gruntsublimecache[gruntFileName].sha1 !== sha1) {
+        var tasks = grunt.task._tasks;
+        
+        _.each( tasks, function( value, key, list ) {
+          // We don't want to shouw or own task
+          if (key === 'expose') {
+            delete list[key];
+          }
+          else {
+            // Filter away reservered words that are none-targets
+            var targets = _.difference(Object.keys(grunt.config.getRaw( key ) || {}), ['files', 'options', 'globals']);
+            
+            if ( targets.length > 0 ) {
+              list[ key ].targets = targets;
+            
+              if ( targets.length > 1 ) {
+                _.each( targets, function(target) {
+                  var name = key + ":" + target;
+
+                  list[name] = { name: name, info: 'Targets ' + name + '. ' + list[key].info || '', meta: { info: list[key].meta&&list[key].meta.info} };
+                });
+              }
             }
           }
-        }
-      });
-      grunt.log.write("EXPOSE_BEGIN" + JSON.stringify(tasks) + "EXPOSE_END");
+        });
+
+        gruntsublimecache[gruntFileName] = gruntsublimecache[gruntFileName] || {};
+        gruntsublimecache[gruntFileName].sha1 = sha1;
+        gruntsublimecache[gruntFileName].tasks = tasks;
+
+        grunt.file.write(cacheFileName, JSON.stringify(gruntsublimecache));
+      }
     }
   );
 };

--- a/main.py
+++ b/main.py
@@ -1,14 +1,13 @@
 import sublime
 import sublime_plugin
 import os
-import re
 import subprocess
 import json
+from hashlib import sha1 
 
 package_name = "Grunt"
 package_url = "https://github.com/tvooo/sublime-grunt"
-
-regex_json = re.compile(r'EXPOSE_BEGIN(.*)EXPOSE_END', re.M | re.I | re.DOTALL)
+cache_file_name = ".sublime-grunt.cache"
 
 
 class GruntRunner(object):
@@ -17,6 +16,16 @@ class GruntRunner(object):
         self.list_gruntfiles()
 
     def list_tasks(self):
+        try:
+            json_result = self.fetch_json()
+        except TypeError:
+            self.window.new_file().run_command("grunt_error", {"message": "SublimeGrunt: JSON is malformed\n\n"})
+            sublime.error_message("Could not read available tasks\n")
+        else:
+            tasks = [[name, task['info'], task['meta']['info']] for name, task in json_result.items()]
+            return sorted(tasks, key=lambda task: task)
+
+    def run_expose(self):
         package_path = os.path.join(sublime.packages_path(), package_name)
 
         args = r'grunt --no-color --tasks "%s" expose' % package_path
@@ -28,25 +37,26 @@ class GruntRunner(object):
             sublime.error_message("\"grunt\" command not found.\nPlease add Grunt's location to your PATH.")
             return
 
-        stdout = stdout.decode('utf8')
-        if stderr:
-            stderr = stderr.decode('utf8')
-        else:
-            stderr = u''
-        json_match = regex_json.search(stdout)
+        return self.fetch_json()
 
-        if json_match is not None:
-            try:
-                json_result = json.loads(json_match.groups()[0])
-            except TypeError:
-                self.window.new_file().run_command("grunt_error", {"message": "SublimeGrunt: JSON is malformed\n\n" + json_match.groups()[0]})
-                sublime.error_message("Could not read available tasks\n")
-            else:
-                tasks = [[name, task['info'], task['meta']['info']] for name, task in json_result.items()]
-                return sorted(tasks, key=lambda task: task)
-        else:
-            self.window.new_file().run_command("grunt_error", {"message": "SublimeGrunt: Could not expose available tasks\n\n" + stdout + "\n\n" + stderr})
-            sublime.error_message("Could not expose available tasks\n")
+    def fetch_json(self):
+        jsonfilename = os.path.join(self.wd, cache_file_name)
+        gruntfile = os.path.join(self.wd, "Gruntfile.js")
+
+        if os.path.exists(jsonfilename):
+           filesha1 = hashfile(gruntfile)
+
+           json_data=open(jsonfilename)
+
+           try:
+                data = json.load(json_data)
+
+                if data[gruntfile]["sha1"] == filesha1:
+                    return data[gruntfile]["tasks"]
+           finally:
+               json_data.close()
+
+        return self.run_expose()
 
     def list_gruntfiles(self):
         self.grunt_files = []
@@ -76,6 +86,19 @@ class GruntRunner(object):
             path = get_env_path()
             exec_args = {'cmd': "grunt --no-color " + self.tasks[task][0], 'shell': True, 'working_dir': self.wd, 'path': path}
             self.window.run_command("exec", exec_args)
+
+
+def hashfile(filepath):
+    f = open(filepath, 'rb')
+
+    try:
+        filehash = sha1()
+        content = f.read()
+        filehash.update("blob " + str(len(content)) + "\0")
+        filehash.update(content)
+        return filehash.hexdigest()
+    finally:
+        f.close()
 
 
 def get_env_path():


### PR DESCRIPTION
Targeting the issues
- #35 by caching the file. Using `git sha1` to check if the file has changed
- #39 by removing output reading from the grunt task we can eliminate platform errors caused by different line-endings on the various platforms/OSes
- #45 Should resolve the same issue as it seems to be the same as in #39

It will try to check if the cache file exists, if it doesn't exists it will try to call the grunt expose task creating the cache.

If the file exists it will read it and try to determine if the ``Gruntfile.js` has changed by comparing the stored `sha1` with our new calculated `sha1`.

When we have a _valid_ cachefile this task is super fast,
