### PR TITLE
Added support for none-latin letters in Grunfile.js

### DIFF
--- a/expose.js
+++ b/expose.js
@@ -1,4 +1,5 @@
-var path = require('path');
+var path = require('path'),
+    fs = require('fs');
 var crypto = require('crypto'),
     shasum = crypto.createHash('sha1');
 
@@ -8,9 +9,9 @@ module.exports = function(grunt) {
   var _ = grunt.util._;
 
   function generatesha1(filename) {
-      var content = grunt.file.read(filename);
+       var content = fs.readFileSync(filename);
  
-      shasum.update("blob " + content.length + '\0');
+      shasum.update("blob " + content.length + '\0', 'utf8');
       shasum.update(content);
 
       return shasum.digest('hex');

--- a/main.py
+++ b/main.py
@@ -100,7 +100,7 @@ def hashfile(filename):
     with open(filename, mode='rb') as f:
         filehash = sha1()
         content = f.read();
-        filehash.update(str("blob " + str(len(content)) + "\0").encode('ascii'))
+        filehash.update(str("blob " + str(len(content)) + "\0").encode('UTF-8'))
         filehash.update(content)
         return filehash.hexdigest()
 


### PR DESCRIPTION
Changed expose to read `Gruntfile.js` as a raw buffer, treat hash header as UTF-8 opposed to ascii.

Solves: #49
