### PR TITLE
Bug fix when using `Gruntfile.coffee`

### DIFF
--- a/expose.js
+++ b/expose.js
@@ -18,9 +18,9 @@ module.exports = function(grunt) {
   }
 
   grunt.registerTask(
-    'expose', "Expose available tasks as JSON object.", function () {
+    'expose', "Expose available tasks as JSON object.", function (gruntFileName) {
       var cwd = process.cwd();
-      var gruntFileName = path.join(cwd, 'Gruntfile.js');
+      gruntFileName = path.join(cwd, gruntFileName);
       var cacheFileName = path.join(cwd, '.sublime-grunt.cache');
       var sha1 = generatesha1(gruntFileName);
         


### PR DESCRIPTION
Before, there were explicit calls for `Gruntfile.js`, now, the chosen
Gruntfile filename is kept so it can be passed to expose.js, accepting
either Gruntfile.js or Gruntfile.coffee.
