### PR TITLE
ST3 - bug fix "quick panel unavailable"

### DIFF
--- a/main.py
+++ b/main.py
@@ -89,7 +89,8 @@ class GruntRunner(object):
 
         self.tasks = self.list_tasks()
         if self.tasks is not None:
-            self.window.show_quick_panel(self.tasks, self.on_done)
+            #fix quick panel unavailable
+            sublime.set_timeout(lambda:  self.window.show_quick_panel(self.tasks, self.on_done), 1)
 
     def on_done(self, task):
         if task > -1:


### PR DESCRIPTION
BUG: The multiple project feature did not work with ST3, nothing happens after the project selection.
Add a set_timeout seem to patch the problem.