### PR TITLE
Rewrote a chunk of `list_gruntfiles()` - fixes #77

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 import sublime
 import sublime_plugin
+import fnmatch
 import os
 import subprocess
 import json
@@ -70,7 +71,10 @@ class GruntRunner(object):
         self.folders = get_grunt_file_paths()
         self.grunt_files = []
         for f in self.window.folders():
-            self.folders.append(f)
+            for root, dirnames, filenames in os.walk(f):
+                for gruntfilename in ['Gruntfile.js', 'Gruntfile.coffee']:
+                    for filename in fnmatch.filter(filenames, gruntfilename):
+                        self.grunt_files.append(os.path.join(root, filename))
 
         for f in self.folders:
             if os.path.exists(os.path.join(f, "Gruntfile.js")):


### PR DESCRIPTION
This is the first piece of Python I've written today after getting stumped by the issue and seeing others had been affected.

The original def just asked for self.window.folders() which isn't a recursive list of the folders in the project. This code replaces the shallow search with a recursive folder search for the `Gruntfile.(js|coffee)`

Instead, my code fires off a search of the file system using `os.walk`. I'm concerned that I might have done something bad as I know hitting the file system could be slow in large projects although I don't see any way around it. If any Python experts have a better idea please tweak it. I'm not sure if this information can be cached either.